### PR TITLE
Release to Docker Hub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+Summary of the PR here. The GitHub release description is created from this comment so keep it nice and descriptive.
+
+Remember to remove sections that you don't need or use.
+
+### Added
+
+- Describe the added features
+
+### Changed
+
+- Describe the outwards facing code change
+
+### Fixed
+
+- Describe the fix and the bug
+
+### Removed
+
+- Describe what was removed and why
+
+### Security
+
+- Describe the security issue and the fix
+
+### Deprecated
+
+- Describe the part of the code being deprecated and why

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build-dotnet:
+    name: Build .NET
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Build
+        run: dotnet build --configuration Release
+        
+  build-docker:
+    name: Build Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - name: Build 
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: .
+          file: ./Docker/Production/Dockerfile
+          build-args: |
+            VERSION=0.0.0
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           push: false
           context: .
-          file: ./Docker/Production/Dockerfile
           build-args: |
             VERSION=0.0.0
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,9 @@ jobs:
           push: true
           context: .
           build-args: |
-            VERSION=${{ needs.setup.outputs.next-version }}
+            VERSION=${{ steps.increment-version.outputs.next-version }}
           platforms: linux/amd64,linux/arm64
-          tags: dolittle/logfeeder:${{ needs.setup.outputs.next-version }}
+          tags: dolittle/logfeeder:${{ steps.increment-version.outputs.next-version }}
       - name: Push Latest Tag to Docker Hub
         uses: docker/build-push-action@v2
         if: ${{ needs.setup.outputs.release-type != 'prerelease' }}
@@ -67,6 +67,6 @@ jobs:
           push: true
           context: .
           build-args: |
-            VERSION=${{ needs.setup.outputs.next-version }}
+            VERSION=${{ steps.increment-version.outputs.next-version }}
           platforms: linux/amd64,linux/arm64
           tags: dolittle/logfeeder:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+env:
+  PRERELEASE_BRANCHES: ''
+  
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  release-docker:
+    name: Release Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+
+      - name: Establish context
+        id: context
+        uses: dolittle/establish-context-action@v2
+        with:
+          prerelease-branches: ${{ env.PRERELEASE_BRANCHES }}
+      - name: Increment version
+        id: increment-version
+        if: ${{ steps.context.outputs.should-publish == 'true' }}
+        uses: dolittle/increment-version-action@v2
+        with:
+          version: ${{ steps.context.outputs.current-version }}
+          release-type: ${{ steps.context.outputs.release-type }}
+      - name: Prepend to Changelog
+        if: ${{ steps.context.outputs.should-publish == 'true' && steps.context.outputs.release-type != 'prerelease' }}
+        uses: dolittle/add-to-changelog-action@v2
+        with:
+          version: ${{ steps.increment-version.outputs.next-version }}
+          body: ${{ steps.context.outputs.pr-body }}
+          pr-url: ${{ steps.context.outputs.pr-url }}
+          changelog-path: CHANGELOG.md
+          user-email: build@dolittle.com
+          user-name: dolittle-build
+      - name: Create GitHub Release
+        id: create-release
+        uses: dolittle/github-release-action@v2
+        if: ${{ steps.context.outputs.should-publish == 'true' }}
+        with:
+          token: ${{ secrets.BUILD_PAT }}
+          version: ${{ steps.increment-version.outputs.next-version }}
+          body: ${{ steps.context.outputs.pr-body }}
+
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push Versioned Tag to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          build-args: |
+            VERSION=${{ needs.setup.outputs.next-version }}
+          platforms: linux/amd64,linux/arm64
+          tags: dolittle/logfeeder:${{ needs.setup.outputs.next-version }}
+      - name: Push Latest Tag to Docker Hub
+        uses: docker/build-push-action@v2
+        if: ${{ needs.setup.outputs.release-type != 'prerelease' }}
+        with:
+          push: true
+          context: .
+          build-args: |
+            VERSION=${{ needs.setup.outputs.next-version }}
+          platforms: linux/amd64,linux/arm64
+          tags: dolittle/logfeeder:latest


### PR DESCRIPTION
## Summary

First release of the LogFeeder application to Docker Hub. See the [README](https://github.com/dolittle-entropy/logfeeder/blob/main/README.md) for instructions on how to run it.